### PR TITLE
feat: Create demo site for top Google Play apps

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -1,0 +1,53 @@
+from flask import Flask, render_template, request
+from gplay_scraper import GPlayScraper
+
+app = Flask(__name__)
+scraper = GPlayScraper()
+
+CATEGORIES = [
+    'APPLICATION', 'ART_AND_DESIGN', 'AUTO_AND_VEHICLES', 'BEAUTY', 'BOOKS_AND_REFERENCE', 'BUSINESS',
+    'COMICS', 'COMMUNICATION', 'DATING', 'EDUCATION', 'ENTERTAINTAINMENT', 'EVENTS',
+    'FINANCE', 'FOOD_AND_DRINK', 'HEALTH_AND_FITNESS', 'HOUSE_AND_HOME',
+    'LIBRARIES_AND_DEMO', 'LIFESTYLE', 'MAPS_AND_NAVIGATION', 'MEDICAL',
+    'MUSIC_AND_AUDIO', 'NEWS_AND_MAGAZINES', 'PARENTING', 'PERSONALIZATION',
+    'PHOTOGRAPHY', 'PRODUCTIVITY', 'SHOPPING', 'SOCIAL', 'SPORTS', 'TOOLS',
+    'TRAVEL_AND_LOCAL', 'VIDEO_PLAYERS', 'WEATHER', 'GAME', 'GAME_ACTION',
+    'GAME_ADVENTURE', 'GAME_ARCADE', 'GAME_BOARD', 'GAME_CARD', 'GAME_CASINO',
+    'GAME_CASUAL', 'GAME_EDUCATIONAL', 'GAME_MUSIC', 'GAME_PUZZLE', 'GAME_RACING',
+    'GAME_ROLE_PLAYING'
+]
+
+COUNTRIES = {
+    'us': 'United States', 'ca': 'Canada', 'mx': 'Mexico', 'pr': 'Puerto Rico',
+    'au': 'Australia', 'in': 'India', 'jp': 'Japan', 'my': 'Malaysia',
+    'nz': 'New Zealand', 'sg': 'Singapore', 'tw': 'Taiwan', 'at': 'Austria',
+    'be': 'Belgium', 'cz': 'Czech Republic', 'dk': 'Denmark', 'ee': 'Estonia',
+    'fi': 'Finland', 'fr': 'France', 'de': 'Germany', 'hu': 'Hungary',
+    'lt': 'Lithuania', 'lv': 'Latvia', 'ro': 'Romania', 'si': 'Slovenia',
+    'sk': 'Slovakia', 'pl': 'Poland', 'ie': 'Ireland', 'it': 'Italy',
+    'nl': 'Netherlands', 'no': 'Norway', 'pt': 'Portugal', 'es': 'Spain',
+    'se': 'Sweden', 'ch': 'Switzerland', 'gb': 'United Kingdom'
+}
+
+@app.route('/')
+def index():
+    category = request.args.get('category', 'APPLICATION')
+    country = request.args.get('country', 'us')
+    apps = scraper.list_analyze(collection='TOP_FREE', category=category, country=country, count=100)
+    return render_template('index.html', apps=apps, categories=CATEGORIES, countries=COUNTRIES,
+                           selected_category=category, selected_country=country)
+
+@app.route('/developer', methods=['GET', 'POST'])
+def developer():
+    apps = None
+    dev_id = ''
+    searched = False
+    if request.method == 'POST':
+        searched = True
+        dev_id = request.form['dev_id']
+        if dev_id:
+            apps = scraper.developer_analyze(dev_id)
+    return render_template('developer.html', apps=apps, dev_id=dev_id, searched=searched)
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/templates/developer.html
+++ b/templates/developer.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Developer Portfolio</title>
+</head>
+<body>
+    <h1>Developer Portfolio</h1>
+    <p>Enter a numeric developer ID to see their apps. For example, Google LLC's ID is 5700313618786177705.</p>
+    <form method="post">
+        <label for="dev_id">Developer ID:</label>
+        <input type="text" name="dev_id" id="dev_id" value="{{ dev_id or '5700313618786177705' }}">
+        <button type="submit">Search</button>
+    </form>
+    {% if searched %}
+        {% if apps %}
+        <h2>Apps for {{ dev_id }}</h2>
+        <table>
+            <thead>
+                <tr>
+                    <th>Title</th>
+                    <th>Installs</th>
+                    <th>Score</th>
+                    <th>Last Updated</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for app in apps %}
+                <tr>
+                    <td>{{ app.title }}</td>
+                    <td>{{ app.installs }}</td>
+                    <td>{{ app.score }}</td>
+                    <td>{{ app.updated }}</td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+        {% else %}
+        <p>No apps found for this developer ID.</p>
+        {% endif %}
+    {% endif %}
+    <p><a href="/">Back to Top Apps</a></p>
+</body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Top Google Play Apps</title>
+</head>
+<body>
+    <h1>Top Google Play Apps</h1>
+    <p><a href="/developer">View Developer Portfolio</a></p>
+    <form method="get">
+        <label for="category">Category:</label>
+        <select name="category" id="category">
+            {% for category in categories %}
+            <option value="{{ category }}" {% if category == selected_category %}selected{% endif %}>{{ category.replace('_', ' ').title() }}</option>
+            {% endfor %}
+        </select>
+        <label for="country">Country:</label>
+        <select name="country" id="country">
+            {% for code, name in countries.items() %}
+            <option value="{{ code }}" {% if code == selected_country %}selected{% endif %}>{{ name }}</option>
+            {% endfor %}
+        </select>
+        <button type="submit">Filter</button>
+    </form>
+    <table>
+        <thead>
+            <tr>
+                <th>Title</th>
+                <th>Developer</th>
+                <th>Score</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for app in apps %}
+            <tr>
+                <td>{{ app.title }}</td>
+                <td>{{ app.developer }}</td>
+                <td>{{ app.score }}</td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</body>
+</html>


### PR DESCRIPTION
This commit introduces a Flask-based demo website to showcase the capabilities of the `gplay-scraper` library.

The site includes two main features:
1.  **Top Apps Browser**: A page that displays the top-ranked free apps from the Google Play Store. Users can filter the results by app category and country using dropdown menus.
2.  **Developer Portfolio**: A page where users can enter a developer's numeric ID to fetch and display a list of all their published applications, along with key performance metrics like installs, score, and last updated date.

The implementation includes:
- A new `demo.py` file containing the Flask application logic.
- HTML templates (`index.html`, `developer.html`) for the user interface.
- Handling for user input and dynamic data fetching from the scraper library.
- Error handling for the developer search to inform the user if no apps are found.

# Pull Request

## Description
Brief description of changes made.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing
- [ ] I have tested my changes locally
- [ ] I have added tests for new functionality
- [ ] All existing tests pass

## Code Quality
- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Related Issues
Fixes #(issue number)

## Additional Notes
Any additional information about the changes.